### PR TITLE
Increase header z-index

### DIFF
--- a/src/components/Header/index.tsx
+++ b/src/components/Header/index.tsx
@@ -27,7 +27,7 @@ const Header = (props: {
 
 
   return (
-    <header className="sticky top-0 z-100 w-full bg-white drop-shadow-1 dark:bg-boxdark dark:drop-shadow-none">
+    <header className="sticky top-0 z-999 w-full bg-white drop-shadow-1 dark:bg-boxdark dark:drop-shadow-none">
       <div className="flex flex-grow items-center justify-between px-4 py-4 shadow-2 md:px-6 2xl:px-11">
         
         <div className="flex items-center gap-2 sm:gap-4">


### PR DESCRIPTION
Flowbite elements have a higher z-index than the header, which breaks rendering